### PR TITLE
Add support for mixed-case query column names

### DIFF
--- a/dump.cfm
+++ b/dump.cfm
@@ -1206,8 +1206,11 @@
 			<cfset LOCAL.cssDeepColor = "##AA66AA">
 			<cfset LOCAL.cssForeColor = "##FFFFFF">
 			<cfset LOCAL.cssSoftColor = "##FFDDFF">
-
-			<cfset LOCAL.columns 		= ARGUMENTS.var.getColumnNames()>
+			<cfif StructKeyExists(server, "lucee")>
+				<cfset LOCAL.columns  = ARGUMENTS.var.ColumnArray()>
+			<cfelse>
+				<cfset LOCAL.columns  = ARGUMENTS.var.getMetaData().getColumnLabels()>
+			</cfif>
 			<cfset LOCAL.columnCount 	= arrayLen(LOCAL.columns)>
 			<cfset LOCAL.len 			= ARGUMENTS.var.recordCount>
 


### PR DESCRIPTION
These platform-specific function preserve the case of the column names. (Previous `getColumnNames()` only supports mixed query column names when dynamically created.)