### PR TITLE
enableCFoutputOnly=true wasn't being unset

### DIFF
--- a/dump.cfm
+++ b/dump.cfm
@@ -488,6 +488,7 @@
 </cfoutput>
 
 <cfif ATTRIBUTES.abort>
+	<cfsetting enableCFoutputOnly="false">
 	<cfabort>
 </cfif>
 
@@ -1671,3 +1672,4 @@
 	<!--- multidimensional array is treated as one dimensional array --->
 	<cfreturn (ARGUMENTS.className & "[]")>
 </cffunction>
+<cfsetting enableCFoutputOnly="false">


### PR DESCRIPTION
enableCFoutputOnly=true was resulting in post-CFTag output being suppressed unless content was within cfoutput/writeoutput.