### PR TITLE
Highlight non-breaking space (NBSP) whitespace characters

### DIFF
--- a/dump.cfm
+++ b/dump.cfm
@@ -259,15 +259,15 @@
 						<cfif (
 							(not ATTRIBUTES.pre) and
 							ATTRIBUTES.wsWarning and (
-								reFind("^\s", ARGUMENTS.var) or
-								reFind("\s$", ARGUMENTS.var)
+								reFind("^[\s|#chr(160)#]", ARGUMENTS.var) or
+								reFind("[\s|#chr(160)#]$", ARGUMENTS.var)
 							)
 						)>
 
 							<cfset LOCAL.title = "This string contains leading or trailing whitespaces, usually unintended. Every whitespace has been replaced with a dot.">
 
 							<cfset LOCAL.cssClass &= " whitespace">
-							<cfset ARGUMENTS.var   = reReplace(ARGUMENTS.var, "\s", ".", "ALL")>
+							<cfset ARGUMENTS.var   = reReplace(ARGUMENTS.var, "[\s|#chr(160)#]", ".", "ALL")>
 
 						</cfif>
 

--- a/dumpmail.cfm
+++ b/dumpmail.cfm
@@ -406,13 +406,13 @@
 						<cfif (
 							(not ATTRIBUTES.pre) and
 							ATTRIBUTES.wsWarning and (
-								reFind("^\s", ARGUMENTS.var) or
-								reFind("\s$", ARGUMENTS.var)
+								reFind("^[\s|#chr(160)#]", ARGUMENTS.var) or
+								reFind("[\s|#chr(160)#]$", ARGUMENTS.var)
 							)
 						)>
 
 							<cfset LOCAL.cssClass &= " whitespace">
-							<cfset ARGUMENTS.var   = reReplace(ARGUMENTS.var, "\s", ".", "ALL")>
+							<cfset ARGUMENTS.var   = reReplace(ARGUMENTS.var, "[\s|#chr(160)#]", ".", "ALL")>
 
 						</cfif>
 


### PR DESCRIPTION
In addition to spaces, tabs, new lines and carriage returnes, a non-breaking space (NBSP; ASCII 160) can often be accidentally appended to strings when copying values from Excel spreadsheets.

If you'd prefer to add support for additional control, invisible and zero-width spaces, I have more character data available here. _(I use this data for an internal CFC that we use to identify whitespace characters that spammers were using to bypass simple word filters.)_
https://gist.github.com/JamoCA/42c3be286185aff0476d5888f0a819ff